### PR TITLE
Remove renaming of output files

### DIFF
--- a/fast_calvo_trainer.py
+++ b/fast_calvo_trainer.py
@@ -103,8 +103,5 @@ class FastCalvoTrainer(RodanTask):
                                       output_path=output_models_path,
                                       epochs=max_number_of_epochs)
 
-        for output_model in output_model_patch:
-            os.rename(output_models_path[output_model] + '.hdf5', output_models_path[output_model])
-
         print('Finishing the Fast CM trainer job.')
         return True


### PR DESCRIPTION
The outputs do not have extensions when generated and do not need to be renamed. Attempting this results in file not found errors.