### PR TITLE
Update to Tensorflow 2.3.2

### DIFF
--- a/recognition_engine.py
+++ b/recognition_engine.py
@@ -4,8 +4,8 @@ import keras
 import cv2
 import numpy as np
 
-from keras.models import load_model
-from keras.backend import image_data_format
+from tensorflow.keras.models import load_model
+from tensorflow.keras.backend import image_data_format
 
 
 def process_image(image, model_path, vspan, hspan):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-h5py==2.7.0
+h5py>=2.10.0
 html5lib==0.9999999
 Keras==2.3.1
 numpy==1.17.3
 opencv-python==3.2.0.8
 scipy==0.19.1
-six==1.10.0
+six>=1.12.0
 tensorflow==2.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ numpy==1.17.3
 opencv-python==3.2.0.8
 scipy==0.19.1
 six==1.10.0
-tensorflow==1.14
+tensorflow==2.3.1

--- a/training_engine.py
+++ b/training_engine.py
@@ -1,13 +1,13 @@
 import cv2
 import numpy as np
 import random as rd
-from keras.models import Sequential, Model
-from keras.layers import Dense, Dropout, Activation, Flatten
-from keras.layers import Conv2D, MaxPooling2D, Input
-from keras.optimizers import Adadelta
-from keras.callbacks import EarlyStopping,ModelCheckpoint
-from keras.backend import image_data_format
-from keras.layers.normalization import BatchNormalization
+from tensorflow.keras.models import Sequential, Model
+from tensorflow.keras.layers import Dense, Dropout, Activation, Flatten
+from tensorflow.keras.layers import Conv2D, MaxPooling2D, Input
+from tensorflow.keras.optimizers import Adadelta
+from tensorflow.keras.callbacks import EarlyStopping,ModelCheckpoint
+from tensorflow.keras.backend import image_data_format
+from tensorflow.keras.layers import BatchNormalization
 
 # ===========================
 #       SETTINGS
@@ -147,6 +147,3 @@ def train_model(input_image, gt, hspan, vspan, output_model_path, max_samples_pe
               epochs=epochs)
 
     return 0
-
-
-

--- a/training_engine.py
+++ b/training_engine.py
@@ -1,6 +1,7 @@
 import cv2
 import numpy as np
 import random as rd
+import os
 from tensorflow.keras.models import Sequential, Model
 from tensorflow.keras.layers import Dense, Dropout, Activation, Flatten
 from tensorflow.keras.layers import Conv2D, MaxPooling2D, Input
@@ -129,8 +130,13 @@ def train_model(input_image, gt, hspan, vspan, output_model_path, max_samples_pe
 
     model.summary()
 
+    # In Tensorflow 2, it is necessary to add '.h5' to the end of the filename to force saving
+    # in hdf5 format with a ModelCheckpoint. Rodan will not accept anything but the file's
+    # original filename, however, so we must rename it back after training.
+    new_output_path = os.path.join(output_model_path + '.h5')
+
     callbacks_list = [
-            ModelCheckpoint(output_model_path, save_best_only=True, monitor='val_acc', verbose=1, mode='max'),
+            ModelCheckpoint(new_output_path, save_best_only=True, monitor='val_acc', verbose=1, mode='max'),
             EarlyStopping(monitor='val_acc', patience=3, verbose=0, mode='max')
             ]
 
@@ -145,5 +151,8 @@ def train_model(input_image, gt, hspan, vspan, output_model_path, max_samples_pe
               validation_split=VALIDATION_SPLIT,
               callbacks=callbacks_list,
               epochs=epochs)
+
+    # Rename the file back to what Rodan expects.
+    os.rename(new_output_path, output_model_path)
 
     return 0

--- a/training_engine_sae.py
+++ b/training_engine_sae.py
@@ -121,28 +121,24 @@ def getTrain(input_image, gt, patch_height, patch_width, max_samples_per_class):
                             X_train[label].append(sample_x)
                             Y_train[label].append(sample_y)
 
-
     # Manage different ordering
     for label in gt:
-        Y_train[label] = np.expand_dims(np.asarray(Y_train[label]),axis=-1)
+        Y_train[label] = np.expand_dims(np.asarray(Y_train[label]), axis=-1)
         if image_data_format() == 'channels_first':
             X_train[label] = np.asarray(X_train[label]).reshape(len(X_train[label]), 3, patch_height, patch_width)
         else:
             X_train[label] = np.asarray(X_train[label]).reshape(len(X_train[label]), patch_height, patch_width, 3)
 
-
     return [X_train, Y_train]
 
 
-
 def train_msae(input_image, gt, height, width, output_path, epochs, max_samples_per_class, batch_size=16):
-
     # Create ground_truth
     [X_train, Y_train] = getTrain(input_image, gt, height, width, max_samples_per_class)
 
     print('Training created with:')
     for label in Y_train:
-        print("\t{} samples of {}".format(len(Y_train[label]),label))
+        print("\t{} samples of {}".format(len(Y_train[label]), label))
 
     # Training loop
     for label in Y_train:
@@ -154,7 +150,7 @@ def train_msae(input_image, gt, height, width, output_path, epochs, max_samples_
 
         model.summary()
         callbacks_list = [
-            ModelCheckpoint(output_path[label], save_best_only=False, save_weights_only=True, monitor='val_accuracy', verbose=1, mode='max'),
+            ModelCheckpoint(output_path[label], save_best_only=True, save_weights_only=False, monitor='val_acc', verbose=1, mode='max'),
             EarlyStopping(monitor='val_accuracy', patience=3, verbose=0, mode='max')
         ]
 

--- a/training_engine_sae.py
+++ b/training_engine_sae.py
@@ -3,12 +3,12 @@ from __future__ import division
 import cv2
 import numpy as np
 import random as rd
-from keras.models import Model
-from keras.layers import Dropout, UpSampling2D, Concatenate
-from keras.layers import Conv2D, MaxPooling2D, Input
-from keras.optimizers import Adam
-from keras.callbacks import EarlyStopping, ModelCheckpoint
-from keras.backend import image_data_format
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dropout, UpSampling2D, Concatenate
+from tensorflow.keras.layers import Conv2D, MaxPooling2D, Input
+from tensorflow.keras.optimizers import Adam
+from tensorflow.keras.callbacks import EarlyStopping, ModelCheckpoint
+from tensorflow.keras.backend import image_data_format
 import keras
 import tensorflow as tf
 
@@ -75,7 +75,7 @@ def get_sae(height, width, pretrained_weights = None):
 
 def getTrain(input_image, gt, patch_height, patch_width, max_samples_per_class):
     # Speed-up factor (TODO this should be a parameter of the job)
-    factor = 100. 
+    factor = 100.
 
     X_train = {}
     Y_train = {}
@@ -93,7 +93,7 @@ def getTrain(input_image, gt, patch_height, patch_width, max_samples_per_class):
     samples_per_class = max_samples_per_class
     for label in gt:
         samples_per_class = min(count[label], samples_per_class)
-    
+
     ratio = {}
     for label in gt:
         ratio[label] = factor * (samples_per_class/float(count[label]))
@@ -106,13 +106,13 @@ def getTrain(input_image, gt, patch_height, patch_width, max_samples_per_class):
             if rd.random() < 1./factor:
 
                 for label in gt:
-                    if gt[label][row][col] == 1:       
+                    if gt[label][row][col] == 1:
                         if rd.random() < ratio[label]: # Take samples according to its ratio
                             from_x = row-(patch_height//2)
                             from_y = col-(patch_width//2)
 
                             sample_x = input_image[from_x:from_x+patch_height,from_y:from_y+patch_width]
-                            
+
                             # Pre-process (check that prediction does the same!)
                             sample_x = (255. - sample_x) / 255.
 
@@ -122,14 +122,14 @@ def getTrain(input_image, gt, patch_height, patch_width, max_samples_per_class):
                             Y_train[label].append(sample_y)
 
 
-    # Manage different ordering 
+    # Manage different ordering
     for label in gt:
         Y_train[label] = np.expand_dims(np.asarray(Y_train[label]),axis=-1)
         if image_data_format() == 'channels_first':
             X_train[label] = np.asarray(X_train[label]).reshape(len(X_train[label]), 3, patch_height, patch_width)
         else:
             X_train[label] = np.asarray(X_train[label]).reshape(len(X_train[label]), patch_height, patch_width, 3)
-    
+
 
     return [X_train, Y_train]
 

--- a/training_engine_sae.py
+++ b/training_engine_sae.py
@@ -3,6 +3,7 @@ from __future__ import division
 import cv2
 import numpy as np
 import random as rd
+import os
 from tensorflow.keras.models import Model
 from tensorflow.keras.layers import Dropout, UpSampling2D, Concatenate
 from tensorflow.keras.layers import Conv2D, MaxPooling2D, Input
@@ -148,9 +149,17 @@ def train_msae(input_image, gt, height, width, output_path, epochs, max_samples_
             width=width
         )
 
+        print('output_paths for layer {}'.format(str(label)))
+        print(output_path)
+
+        # In Tensorflow 2, it is necessary to add '.h5' to the end of the filename to force saving
+        # in hdf5 format with a ModelCheckpoint. Rodan will not accept anything but the file's
+        # original filename, however, so we must rename it back after training.
+        new_output_path = os.path.join(output_path[label] + '.h5')
+
         model.summary()
         callbacks_list = [
-            ModelCheckpoint(output_path[label], save_best_only=True, save_weights_only=False, monitor='val_acc', verbose=1, mode='max'),
+            ModelCheckpoint(new_output_path, save_best_only=True, save_weights_only=False, monitor='val_accuracy', verbose=1, mode='max'),
             EarlyStopping(monitor='val_accuracy', patience=3, verbose=0, mode='max')
         ]
 
@@ -164,6 +173,10 @@ def train_msae(input_image, gt, height, width, output_path, epochs, max_samples_
             callbacks=callbacks_list,
             epochs=epochs
         )
+
+        # Rename the file back to what Rodan expects.
+        os.rename(new_output_path, output_path[label])
+
 
     return 0
 

--- a/training_engine_sae.py
+++ b/training_engine_sae.py
@@ -154,7 +154,7 @@ def train_msae(input_image, gt, height, width, output_path, epochs, max_samples_
 
         model.summary()
         callbacks_list = [
-            ModelCheckpoint(output_path[label], save_best_only=True, monitor='val_accuracy', verbose=1, mode='max'),
+            ModelCheckpoint(output_path[label], save_best_only=False, save_weights_only=True, monitor='val_accuracy', verbose=1, mode='max'),
             EarlyStopping(monitor='val_accuracy', patience=3, verbose=0, mode='max')
         ]
 


### PR DESCRIPTION
Only a few changes were necessary to get this job working (both training and inference) in tf2.3.2:

- All statements of `import keras.some_module` were changed to `import tensorflow.keras.some_module`
- `keras.layers.normalization.BatchNormalization` is now `tensorflow.keras.layers.BatchNormalization`
- Tensorflow 2.3.2 does not save models as hdf5 files by default, and to trigger this with a callback from `ModelCheckpoint` it is necessary to pass a filename ending in `.h5`. Rodan does not want files ending in `.h5`, though, so we must change the name back after the model is created.
- Dependencies of tensorflow 2.3.2 are also updated in `requirements.txt`. (I chose 2.3.2 specifically because 2.4.x seems to require numpy>1.18.x, which has some particular modules deprecated, causing errors when launching celery/rodan).