### PR TITLE
Var fix napulen

### DIFF
--- a/local_fast_trainer.py
+++ b/local_fast_trainer.py
@@ -1,16 +1,16 @@
 """Local Fast Trainer
-This is the file for running Calvo Fast Trainer loaclly. Make sure 
+This is the file for running Calvo Fast Trainer loaclly. Make sure
 to have an 'Images' folder with the correct inputs in the same directory.
-If not, you can change the values in 'inputs' and 'outputs'. 
+If not, you can change the values in 'inputs' and 'outputs'.
 
 Simply run `python local_fast_trainer.py` to see the output.
 This will call `training_engine_sae.py`.
 
 It should generate 3 files in its current state. A background model,
-a Model 0, and a Log File. 
+a Model 0, and a Log File.
 
 If you're running it in a Rodan container, this will be located in code/Rodan/rodan/jobs/Calvo_classifier
-If the container is already running, try `docker exec -it [container_name] bash` to run the script without 
+If the container is already running, try `docker exec -it [container_name] bash` to run the script without
 stopping.
 """
 
@@ -67,7 +67,7 @@ gts = []
 output_models_path = {}
 
 for idx in range(number_of_training_pages):
-    input_image = cv2.imread(inputs["Image"][idx]["resource_path"], True)  # 3-channel
+    input_image = cv2.imread(inputs["Image"][idx]["resource_path"], cv2.IMREAD_COLOR)  # 3-channel
     background = cv2.imread(
         inputs["rgba PNG - Layer 0 (Background)"][idx]["resource_path"],
         cv2.IMREAD_UNCHANGED,

--- a/local_fast_trainer.py
+++ b/local_fast_trainer.py
@@ -79,11 +79,12 @@ for idx in range(number_of_training_pages):
 
     # Create categorical ground-truth
     gt = {}
-    regions_mask = regions[:, :, 3] == 255
+    TRANSPARENCY = 3
+    regions_mask = regions[:, :, TRANSPARENCY] == 255
     # background is already restricted to the selected regions (based on Pixel.js' behaviour)
 
     # Populate remaining inputs and outputs
-    bg_mask = background[:, :, 3] == 255
+    bg_mask = background[:, :, TRANSPARENCY] == 255
     gt["0"] = np.logical_and(bg_mask, regions_mask)
 
     for i in range(1, int_model):
@@ -91,7 +92,7 @@ for idx in range(number_of_training_pages):
             inputs["rgba PNG - Layer {layer_num}".format(layer_num=i)][idx]["resource_path"],
             cv2.IMREAD_UNCHANGED,
         )
-        file_mask = file_obj[:, :, 3] == 255
+        file_mask = file_obj[:, :, TRANSPARENCY] == 255
         gt[str(i)] = np.logical_and(file_mask, regions_mask)
 
     input_images.append(input_image)

--- a/training_engine_sae.py
+++ b/training_engine_sae.py
@@ -129,13 +129,13 @@ def threadsafe_generator(f):
 
 
 @threadsafe_generator  # Credit: https://anandology.com/blog/using-iterators-and-generators/
-def createGenerator(grs, gts, idx_label, patch_height, patch_width, batch_size):
+def createGenerator(input_images, segmented_images, idx_label, patch_height, patch_width, batch_size):
     while True:
 
-        selected_page_idx = np.random.randint(len(grs))  # Changed len to grs from gr
-        gr = grs[selected_page_idx]
+        selected_page_idx = np.random.randint(len(input_images))  # Changed len to grs from gr
+        gr = input_images[selected_page_idx]
         label = str(idx_label)
-        gt = gts[selected_page_idx][label]
+        gt = segmented_images[selected_page_idx][label]
 
         potential_training_examples = np.where(gt[:-patch_height, :-patch_width] == 1)
 

--- a/training_engine_sae.py
+++ b/training_engine_sae.py
@@ -137,19 +137,18 @@ def createGenerator(grs, gts, idx_label, patch_height, patch_width, batch_size):
         label = str(idx_label)
         gt = gts[selected_page_idx][label]
 
-        x_coords, y_coords = np.where(gt == 1)
-        coords_with_info = (x_coords, y_coords)
+        potential_training_examples = np.where(gt == 1)
 
         gr_chunks = []
         gt_chunks = []
 
-        num_coords = len(coords_with_info[0])
+        num_coords = len(potential_training_examples[0])
 
         index_coords_selected = [
             np.random.randint(0, num_coords) for _ in range(batch_size)
         ]
-        x_coords = coords_with_info[0][index_coords_selected]
-        y_coords = coords_with_info[1][index_coords_selected]
+        x_coords = potential_training_examples[0][index_coords_selected]
+        y_coords = potential_training_examples[1][index_coords_selected]
 
         for i in range(batch_size):
             row = x_coords[i]

--- a/training_engine_sae.py
+++ b/training_engine_sae.py
@@ -137,7 +137,7 @@ def createGenerator(grs, gts, idx_label, patch_height, patch_width, batch_size):
         label = str(idx_label)
         gt = gts[selected_page_idx][label]
 
-        potential_training_examples = np.where(gt == 1)
+        potential_training_examples = np.where(gt[:-patch_height, :-patch_width] == 1)
 
         gr_chunks = []
         gt_chunks = []


### PR DESCRIPTION
Fixes the issue related to the random selection of pixels used as training examples.

The pixels should be selected so that enough context can be provided to respect the `width` and `height` of the patch.